### PR TITLE
初始化函数调用错误

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -15,9 +15,9 @@ APP_KEY = os.environ['LEANCLOUD_APP_KEY']
 MASTER_KEY = os.environ['LEANCLOUD_APP_MASTER_KEY']
 PORT = int(os.environ['LEANCLOUD_APP_PORT'])
 
-leancloud.init(APP_ID, app_key=APP_KEY, master_key=MASTER_KEY)
+leancloud.client.init(APP_ID, app_key=APP_KEY, master_key=MASTER_KEY)
 # 如果需要使用 master key 权限访问 LeanCLoud 服务，请将这里设置为 True
-leancloud.use_master_key(False)
+leancloud.client.use_master_key(False)
 
 application = engine
 


### PR DESCRIPTION
leancloud无init函数, 应使用leanclound.client.init(), 否则导致无法deploy